### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
+[![Board Status](https://dev.azure.com/dpilarski/3c9d47b5-4240-4dc2-810a-f9ffe89b4bfd/e8cb6b1e-d7ba-4a4c-9927-99bea633c6e6/_apis/work/boardbadge/df752a7f-4b6d-44e2-81ec-28863849989e)](https://dev.azure.com/dpilarski/3c9d47b5-4240-4dc2-810a-f9ffe89b4bfd/_boards/board/t/e8cb6b1e-d7ba-4a4c-9927-99bea633c6e6/Microsoft.RequirementCategory)
 # RetailManager
  A retail management system


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#14](https://dev.azure.com/dpilarski/3c9d47b5-4240-4dc2-810a-f9ffe89b4bfd/_workitems/edit/14). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.